### PR TITLE
Fix typo preventing collisions with entities

### DIFF
--- a/part_5/src/Entities/entity.gd
+++ b/part_5/src/Entities/entity.gd
@@ -26,7 +26,7 @@ func move(move_offset: Vector2i) -> void:
 
 
 func is_blocking_movement() -> bool:
-	return _definition.is_blocking_movment
+	return _definition.is_blocking_movement
 
 
 func get_entity_name() -> String:


### PR DESCRIPTION
Colliding with an entity results in "Invalid get index 'is_blocking_movment' (on base: 'Resource (EntityDefinition)')". 

This appears to have been fixed in the subsequent parts of the tutorial.