### PR TITLE
Add leveled_up.emit() to increase_level func

### DIFF
--- a/part_11/src/Entities/Actors/Components/level_component.gd
+++ b/part_11/src/Entities/Actors/Components/level_component.gd
@@ -41,6 +41,7 @@ func add_xp(xp: int) -> void:
 func increase_level() -> void:
 	current_xp -= get_experience_to_next_level()
 	current_level += 1
+	leveled_up.emit()
 
 
 func increase_max_hp(amount: int = 20) -> void:

--- a/part_12/src/Entities/Actors/Components/level_component.gd
+++ b/part_12/src/Entities/Actors/Components/level_component.gd
@@ -41,6 +41,7 @@ func add_xp(xp: int) -> void:
 func increase_level() -> void:
 	current_xp -= get_experience_to_next_level()
 	current_level += 1
+	leveled_up.emit()
 
 
 func increase_max_hp(amount: int = 20) -> void:

--- a/part_13/src/Entities/Actors/Components/level_component.gd
+++ b/part_13/src/Entities/Actors/Components/level_component.gd
@@ -41,6 +41,7 @@ func add_xp(xp: int) -> void:
 func increase_level() -> void:
 	current_xp -= get_experience_to_next_level()
 	current_level += 1
+	leveled_up.emit()
 
 
 func increase_max_hp(amount: int = 20) -> void:


### PR DESCRIPTION
Noticed after the tutorial and cloning down the official copy to double check that levelling up did not update the display due to the signal not being emit from the `increase_level` function that the display listens for.